### PR TITLE
Update serializers.py

### DIFF
--- a/backend/accounts/api/serializers.py
+++ b/backend/accounts/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
-from rest_framework.compat import authenticate
+from django.contrib.auth import authenticate
 from rest_framework.validators import UniqueValidator
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from accounts.models import UserProfile


### PR DESCRIPTION
fix “ImportError: cannot import name 'authenticate' from 'rest_framework.compat'”